### PR TITLE
Add curl-native dependency

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -11,6 +11,7 @@ CVE_PRODUCT = "libflutter_engine.so"
 DEPENDS += "depot-tools-native \
             fontconfig \
             zip-native \
+            curl-native \
             "
 
 SRC_URI = "file://0001-clang-toolchain.patch \


### PR DESCRIPTION
curl is required by download_dart_sdk.py.

```
| ________ running 'python3 src/flutter/tools/download_dart_sdk.py' in '/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0'
| multiprocessing.pool.RemoteTraceback:
| """
| Traceback (most recent call last):
|   File "/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0/recipe-sysroot-native/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
|     result = (True, func(*args, **kwds))
|   File "src/flutter/tools/download_dart_sdk.py", line 178, in DownloadAndExtract
|     archive = DownloadDartSDK(channel, version, os_name, arch, verbose)
|   File "src/flutter/tools/download_dart_sdk.py", line 113, in DownloadDartSDK
|     curl_result = subprocess.run(
|   File "/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0/recipe-sysroot-native/usr/lib/python3.8/subprocess.py", line 493, in run
|     with Popen(*popenargs, **kwargs) as process:
|   File "/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0/recipe-sysroot-native/usr/lib/python3.8/subprocess.py", line 858, in __init__
|     self._execute_child(args, executable, preexec_fn, close_fds,
|   File "/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0/recipe-sysroot-native/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
|     raise child_exception_type(errno_num, err_msg, err_filename)
| FileNotFoundError: [Errno 2] No such file or directory: 'curl'
| """
|
| The above exception was the direct cause of the following exception:
|
| Traceback (most recent call last):
|   File "src/flutter/tools/download_dart_sdk.py", line 263, in <module>
|     sys.exit(Main())
|   File "src/flutter/tools/download_dart_sdk.py", line 256, in Main
|     result = async_result.get()
|   File "/home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0/recipe-sysroot-native/usr/lib/python3.8/multiprocessing/pool.py", line 771, in get
|     raise self._value
| FileNotFoundError: [Errno 2] No such file or directory: 'curl'
| Error: Command 'python3 src/flutter/tools/download_dart_sdk.py' returned non-zero exit status 1 in /home/user/yocto/build/tmp/work/aarch64-poky-linux/flutter-engine/git-r0
| Hook 'python3 src/flutter/tools/download_dart_sdk.py' took 12.79 secs
| WARNING: exit code 2 from a shell command.
|
ERROR: Task (/home/user/yocto/build/../meta-flutter/recipes-graphics/flutter-engine/flutter-engine_git.bb:do_patch) failed with exit code '1'

```